### PR TITLE
remove language dependent terms from regular expressions

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -14,18 +14,20 @@ const fixBrokenHTML = (sourceHTML) => {
 };
 
 const highlightType = (text) => {
-  return text.startsWith("Highlight") ? "Highlight" : "Note";
-};
+  const match = text.match(/^(.*)\s-\s/);
+  if (match) {
+    return match[1];
+  }};
 
 const extractPageNumber = (text) => {
-  const match = text.match(/Page\s+([0-9]+)/);
+  const match = text.match(/\s-\s\w*\s+([0-9]+)/);
   if (match) {
     return match[1];
   }
 };
 
 const extractLocation = (text) => {
-  const match = text.match(/Location\s+([0-9]+)/);
+  const match = text.match(/\s·\s\w*\s+([0-9]+)/);
   if (match) {
     return match[1];
   }


### PR DESCRIPTION
This should fix #1. Please check again with exports in your language.